### PR TITLE
Fix income multiplier

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -146,11 +146,11 @@ define(
     CheungKong:
     {
         title:"Li's Enterprise Headquarter",
-        description:"Earn double and upgrade Repel Tower. Income does not stack, but upgrades do.",
+        description:"Earn 50% more and upgrade Repel Tower. Income does not stack, but upgrades do.",
         power: -50,
         cost: 7000,
         buildEffectColor: "red",
-        hsiIncrementMultiplier: 2,
+        hsiIncrementMultiplier: 1.5,
         repelTowerRangeIncrease: 20,
         repelTowerForceIncrease: 70,
         repelTowerCostDecrease: 30,

--- a/js/game.js
+++ b/js/game.js
@@ -252,8 +252,8 @@ define([
 				//TODO could be optimize
 				//
 				var hsiChange = (Config.HSI.increment + Math.round(Math.random() * Config.HSI.upperOfRandom) + Math.round(Math.random() * Config.HSI.lowerOfRandom));
-				if (this.built.cheungKongLimited)
-					hsiChange *= Config.CheungKong.hsiIncrementMultiplier;
+				if (this.isBuilt('CheungKongLimited'))
+					hsiChange = Math.round(hsiChange * Config.CheungKong.hsiIncrementMultiplier);
 				for (var i = Stage.displayList['typhoons'].length - 1; i >= 0; i--) {
 					var e = Stage.displayList['typhoons'][i];
 					// skip if typhoon is destroyed


### PR DESCRIPTION
The income multiplier for the headquarters building wasn't taking effect. After fixing this, the modifier feels OP. I've adjusted it down from 2x to 1.5x and that seems a lot better. WDYT?
